### PR TITLE
modify setup.py to remove filename.as_posix causing bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read_requirements_from_here(here: Path, filename: str = None) -> list:
     assert filename is not None, "filename as string must be provided"
     assert here.with_name(
         filename
-    ).exists(), f"requirements filename {filename.as_posix()} does not exist"
+    ).exists(), f"requirements filename {filename} does not exist"
     with open(here.with_name(filename)) as requirements_file:
         # Parse requirements.txt, ignoring any commented-out lines.
         requirements = [


### PR DESCRIPTION
This pull modifies the read_requirements_from_here function in setup.py to remove a bug. Currently if a file does not exist and fails the assertation, a string is printed including `filename.as_posix`. This causes the error `AttributeError: 'str' object has no attribute 'as_posix' ` because filename is a string, and [as_posix ](https://docs.python.org/3/library/pathlib.html) acts on path objects to convert them to strings. This pull fixes this by removing `as_posix`
