### PR TITLE
Security: Do not log username and token

### DIFF
--- a/pyscicat/client.py
+++ b/pyscicat/client.py
@@ -646,7 +646,7 @@ def from_credentials(base_url: str, username: str, password: str):
 def get_token(base_url, username, password):
     """logs in using the provided username / password combination
     and receives token for further communication use"""
-    logger.info(f" Getting new token for user {username}")
+    logger.info(f" Getting new token")
     if base_url[-1] != "/":
         base_url = base_url + "/"
     response = requests.post(
@@ -662,7 +662,4 @@ def get_token(base_url, username, password):
         raise ScicatLoginError(response.content)
 
     data = response.json()
-    # print("Response:", data)
-    token = data["id"]  # not sure if semantically correct
-    logger.info(f" token: {token}")
-    return token
+    return data["id"]  # not sure if semantically correct

--- a/pyscicat/client.py
+++ b/pyscicat/client.py
@@ -646,7 +646,7 @@ def from_credentials(base_url: str, username: str, password: str):
 def get_token(base_url, username, password):
     """logs in using the provided username / password combination
     and receives token for further communication use"""
-    logger.info(f" Getting new token")
+    logger.info(" Getting new token")
     if base_url[-1] != "/":
         base_url = base_url + "/"
     response = requests.post(


### PR DESCRIPTION
Storing these credentials in a log (file) as plain text is a security risk. Especially when log files are uploaded and linked to a SciCat dataset.