### PR TITLE
Multiple fixes for new backend

### DIFF
--- a/pyscicat/client.py
+++ b/pyscicat/client.py
@@ -113,16 +113,16 @@ class ScicatClient:
         response = self._send_to_scicat(cmd=cmd, endpoint=endpoint, data=data)
         result = response.json()
         if not response.ok:
-            err = result.get("error", {})
+            # err = result.get("error", {})
             if (
                 allow_404
                 and response.status_code == 404
-                and re.match(r"Unknown (.+ )?id", err.get("message", ""))
+                and re.match(r"Unknown (.+ )?id", result)
             ):
                 # The operation failed but because the object does not exist in SciCat.
-                logger.error("Error in operation %s: %s", operation, err)
+                logger.error("Error in operation %s: %s", operation, result)
                 return None
-            raise ScicatCommError(f"Error in operation {operation}: {err}")
+            raise ScicatCommError(f"Error in operation {operation}: {result}")
         logger.info(
             "Operation '%s' successful%s",
             operation,

--- a/pyscicat/client.py
+++ b/pyscicat/client.py
@@ -5,7 +5,6 @@ import base64
 import hashlib
 import logging
 import json
-import re
 from typing import Optional
 from urllib.parse import urljoin, quote_plus
 
@@ -114,11 +113,11 @@ class ScicatClient:
         result = response.json() if len(response.content) > 0 else None
         if not response.ok:
             raise ScicatCommError(f"Error in operation {operation}: {result}")
-            
+
         logger.info(
             "Operation '%s' successful%s",
             operation,
-            f"pid={result['pid']}" if "pid" in result else "",
+            f"pid={result['pid']}" if result and "pid" in result else "",
         )
         return result
 

--- a/pyscicat/client.py
+++ b/pyscicat/client.py
@@ -15,9 +15,9 @@ import requests
 
 from pyscicat.model import (
     Attachment,
+    CreateDatasetOrigDatablockDto,
     Dataset,
     Instrument,
-    OrigDatablock,
     Proposal,
     Sample,
 )
@@ -111,7 +111,8 @@ class ScicatClient:
         allow_404=False,
     ) -> Optional[dict]:
         response = self._send_to_scicat(cmd=cmd, endpoint=endpoint, data=data)
-        result = response.json()
+
+        result = response.json() if len(response.content) > 0 else None
         if not response.ok:
             # err = result.get("error", {})
             if (
@@ -123,6 +124,7 @@ class ScicatClient:
                 logger.error("Error in operation %s: %s", operation, result)
                 return None
             raise ScicatCommError(f"Error in operation {operation}: {result}")
+            
         logger.info(
             "Operation '%s' successful%s",
             operation,
@@ -200,7 +202,9 @@ class ScicatClient:
     """
     update_dataset = datasets_update
 
-    def datasets_origdatablock_create(self, origdatablock: OrigDatablock) -> dict:
+    def datasets_origdatablock_create(
+        self, dataset_id: str, datablockDto: CreateDatasetOrigDatablockDto
+    ) -> dict:
         """
         Create a new SciCat Dataset OrigDatablock
         This function has been renamed.
@@ -223,11 +227,11 @@ class ScicatClient:
             Raises if a non-20x message is returned
 
         """
-        endpoint = f"Datasets/{quote_plus(origdatablock.datasetId)}/origdatablocks"
+        endpoint = f"Datasets/{quote_plus(dataset_id)}/origdatablocks"
         return self._call_endpoint(
             cmd="post",
             endpoint=endpoint,
-            data=origdatablock,
+            data=datablockDto,
             operation="datasets_origdatablock_create",
         )
 

--- a/pyscicat/client.py
+++ b/pyscicat/client.py
@@ -108,21 +108,11 @@ class ScicatClient:
         endpoint: str,
         data: BaseModel = None,
         operation: str = "",
-        allow_404=False,
     ) -> Optional[dict]:
         response = self._send_to_scicat(cmd=cmd, endpoint=endpoint, data=data)
 
         result = response.json() if len(response.content) > 0 else None
         if not response.ok:
-            # err = result.get("error", {})
-            if (
-                allow_404
-                and response.status_code == 404
-                and re.match(r"Unknown (.+ )?id", result)
-            ):
-                # The operation failed but because the object does not exist in SciCat.
-                logger.error("Error in operation %s: %s", operation, result)
-                return None
             raise ScicatCommError(f"Error in operation {operation}: {result}")
             
         logger.info(
@@ -522,7 +512,6 @@ class ScicatClient:
             cmd="get",
             endpoint=f"Datasets/fullquery?{query}",
             operation="datasets_find",
-            allow_404=True,
         )
 
     """
@@ -563,7 +552,7 @@ class ScicatClient:
         filter_fields = json.dumps(filter_fields)
         endpoint = f'Datasets?filter={{"where":{filter_fields}}}'
         return self._call_endpoint(
-            cmd="get", endpoint=endpoint, operation="datasets_get_many", allow_404=True
+            cmd="get", endpoint=endpoint, operation="datasets_get_many"
         )
 
     """
@@ -599,7 +588,6 @@ class ScicatClient:
             cmd="get",
             endpoint=endpoint,
             operation="published_data_get_many",
-            allow_404=True,
         )
 
     """
@@ -624,7 +612,6 @@ class ScicatClient:
             cmd="get",
             endpoint=f"Datasets/{quote_plus(pid)}",
             operation="datasets_get_one",
-            allow_404=True,
         )
 
     get_dataset_by_pid = datasets_get_one
@@ -663,7 +650,6 @@ class ScicatClient:
             cmd="get",
             endpoint=endpoint,
             operation="instruments_get_one",
-            allow_404=True,
         )
 
     get_instrument = instruments_get_one
@@ -689,7 +675,6 @@ class ScicatClient:
             cmd="get",
             endpoint=f"Samples/{quote_plus(pid)}",
             operation="samples_get_one",
-            allow_404=True,
         )
 
     get_sample = samples_get_one
@@ -711,7 +696,7 @@ class ScicatClient:
             The proposal with the requested pid
         """
         return self._call_endpoint(
-            cmd="get", endpoint=f"Proposals/{quote_plus(pid)}", allow_404=True
+            cmd="get", endpoint=f"Proposals/{quote_plus(pid)}"
         )
 
     get_proposal = proposals_get_one
@@ -736,7 +721,6 @@ class ScicatClient:
             cmd="get",
             endpoint=f"Datasets/{quote_plus(pid)}/origdatablocks",
             operation="datasets_origdatablocks_get_one",
-            allow_404=True,
         )
 
     get_dataset_origdatablocks = datasets_origdatablocks_get_one
@@ -761,7 +745,6 @@ class ScicatClient:
             cmd="delete",
             endpoint=f"Datasets/{quote_plus(pid)}",
             operation="datasets_delete",
-            allow_404=True,
         )
 
     delete_dataset = datasets_delete

--- a/pyscicat/client.py
+++ b/pyscicat/client.py
@@ -831,7 +831,6 @@ def get_token(base_url, username, password):
     if response.ok:
         return response.json()["access_token"]
 
-    err = response.json()["error"]
     logger.error(
         f' Failed log in:  {response.json()}'
     )

--- a/pyscicat/client.py
+++ b/pyscicat/client.py
@@ -809,9 +809,8 @@ def _log_in_via_auth_msad(base_url, username, password):
         verify=True,
     )
     if not response.ok:
-        err = response.json()["error"]
         logger.error(
-            f'Error retrieving token for user: {err["name"]}, {err["statusCode"]}: {err["message"]}'
+            f'Error retrieving token for user: {response.json()}'
         )
         raise ScicatLoginError(response.content)
 
@@ -834,6 +833,6 @@ def get_token(base_url, username, password):
 
     err = response.json()["error"]
     logger.error(
-        f' Failed log in:  {err["name"]}, {err["statusCode"]}: {err["message"]}'
+        f' Failed log in:  {response.json()}'
     )
     raise ScicatLoginError(response.content)

--- a/pyscicat/model.py
+++ b/pyscicat/model.py
@@ -90,7 +90,9 @@ class Job(MongoQueryable):
     executionTime: Optional[str] = None
     jobParams: Optional[dict] = None
     jobStatusMessage: Optional[str] = None
-    datasetList: Optional[dict] = None  # documentation says dict, but should maybe be list?
+    datasetList: Optional[
+        dict
+    ] = None  # documentation says dict, but should maybe be list?
     jobResultObject: Optional[dict] = None  # ibid.
 
 
@@ -115,7 +117,9 @@ class Dataset(Ownable):
     creationTime: str  # datetime
     datasetName: Optional[str] = None
     description: Optional[str] = None
-    history: Optional[List[dict]] = None  # list of foreigh key ids to the Messages table
+    history: Optional[
+        List[dict]
+    ] = None  # list of foreigh key ids to the Messages table
     instrumentId: Optional[str] = None
     isPublished: Optional[bool] = False
     keywords: Optional[List[str]] = None
@@ -187,25 +191,31 @@ class Datablock(Ownable):
 
     id: Optional[str] = None
     # archiveId: str = None  listed in catamel model, but comes back invalid?
-    size: int
+
     packedSize: Optional[int] = None
     chkAlg: Optional[int] = None
     version: str = None
     instrumentGroup: Optional[str] = None
-    dataFileList: List[DataFile]
     datasetId: str
 
 
-class OrigDatablock(Ownable):
+class CreateDatasetOrigDatablockDto(BaseModel):
+    """
+    DTO for creating a new dataset with an original datablock
+    """
+
+    chkAlg: Optional[int] = None
+    dataFileList: List[DataFile]
+    size: int
+
+
+class OrigDatablock(Ownable, CreateDatasetOrigDatablockDto):
     """
     An Original Datablock maps between a Dataset and contains DataFiles
     """
 
     id: Optional[str] = None
-    # archiveId: str = None  listed in catamel model, but comes back invalid?
-    size: int
     instrumentGroup: Optional[str] = None
-    dataFileList: List[DataFile]
     datasetId: str
 
 

--- a/tests/test_pyscicat/test_client.py
+++ b/tests/test_pyscicat/test_client.py
@@ -14,7 +14,7 @@ from pyscicat.client import (
 
 from pyscicat.model import (
     Attachment,
-    Datablock,
+    CreateDatasetOrigDatablockDto,
     DataFile,
     Instrument,
     Proposal,
@@ -138,14 +138,13 @@ def test_scicat_ingest():
 
         # Datablock with DataFiles
         data_file = DataFile(path="/foo/bar", size=42)
-        data_block = Datablock(
+        data_block_dto = CreateDatasetOrigDatablockDto(
             size=42,
-            version="1",
             datasetId=dataset_id,
             dataFileList=[data_file],
-            **ownable.dict()
+
         )
-        scicat.upload_dataset_origdatablock(data_block)
+        scicat.upload_dataset_origdatablock(dataset_id, data_block_dto)
 
         # Attachment
         attachment = Attachment(
@@ -187,17 +186,9 @@ def test_get_dataset():
 def test_get_nonexistent_dataset():
     with requests_mock.Mocker() as mock_request:
         mock_request.get(
-            local_url + "Datasets/74",
-            status_code=404,
-            reason="Not Found",
-            json={
-                "error": {
-                    "statusCode": 404,
-                    "name": "Error",
-                    "message": 'Unknown "Dataset" id "74".',
-                    "code": "MODEL_NOT_FOUND",
-                }
-            },
+            local_url + "datasets/74",
+            status_code=200,
+            content=b''
         )
         client = from_token(base_url=local_url, token="a_token")
         assert client.datasets_get_one("74") is None
@@ -206,7 +197,7 @@ def test_get_nonexistent_dataset():
 def test_get_dataset_bad_url():
     with requests_mock.Mocker() as mock_request:
         mock_request.get(
-            "http://localhost:3000/api/v100/Datasets/53",
+            "http://localhost:3000/api/v100/datasets/53",
             status_code=404,
             reason="Not Found",
             json={
@@ -228,3 +219,8 @@ def test_initializers():
 
         client = from_token(local_url, "let me in!")
         assert client._token == "let me in!"
+
+def test_real():
+    client = from_token(base_url="http://localhost:3000/api/wer3", token="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJfaWQiOiI2NTE1ZGYwNWM4OGNhMzNkODkzNjA3NjkiLCJ1c2VybmFtZSI6ImluZ2VzdG9yIiwiZW1haWwiOiJzY2ljYXRpbmdlc3RvckB5b3VyLnNpdGUiLCJhdXRoU3RyYXRlZ3kiOiJsb2NhbCIsIl9fdiI6MCwiaWQiOiI2NTE1ZGYwNWM4OGNhMzNkODkzNjA3NjkiLCJpYXQiOjE2OTU5OTMyMTcsImV4cCI6MTY5NTk5NjgxN30.Dc-K39ikfSixMGXzURrJ0Z4lHwZGOzRWlpeU2u5fdIA")
+    response = client.datasets_get_one("sdfsdfl")
+    print(response)

--- a/tests/test_pyscicat/test_client.py
+++ b/tests/test_pyscicat/test_client.py
@@ -219,8 +219,3 @@ def test_initializers():
 
         client = from_token(local_url, "let me in!")
         assert client._token == "let me in!"
-
-def test_real():
-    client = from_token(base_url="http://localhost:3000/api/wer3", token="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJfaWQiOiI2NTE1ZGYwNWM4OGNhMzNkODkzNjA3NjkiLCJ1c2VybmFtZSI6ImluZ2VzdG9yIiwiZW1haWwiOiJzY2ljYXRpbmdlc3RvckB5b3VyLnNpdGUiLCJhdXRoU3RyYXRlZ3kiOiJsb2NhbCIsIl9fdiI6MCwiaWQiOiI2NTE1ZGYwNWM4OGNhMzNkODkzNjA3NjkiLCJpYXQiOjE2OTU5OTMyMTcsImV4cCI6MTY5NTk5NjgxN30.Dc-K39ikfSixMGXzURrJ0Z4lHwZGOzRWlpeU2u5fdIA")
-    response = client.datasets_get_one("sdfsdfl")
-    print(response)


### PR DESCRIPTION
Some small fixes for issues found testing against the new backend:

- The new backend reports errors directly in the message body, while the old backed used an "err" object in the json.
- The new backend reports status and errors differently from the old backend, this accommodates those changes. One major change is that there was an inconsistency in reporting 404. Because of this, @jl-wynen added a mechanism in the client code to specify that operations not throw errors if the return is a 404. This PR removes that because as far as I can tell, the new backend only reports 404s when the URL path is bad, in which case throwing a ScicatCommError is desirable.