### PR TITLE
Fix auth error in from_token, from_credentials

### DIFF
--- a/pyscicat/client.py
+++ b/pyscicat/client.py
@@ -85,7 +85,7 @@ class ScicatClient:
                 self._password is not None
             ), "SciCat login credentials (username, password) must be provided if token is not provided"
             self._token = get_token(self._base_url, self._username, self._password)
-            self._headers["Authorization"] = "Bearer {}".format(self._token)
+        self._headers["Authorization"] = "Bearer {}".format(self._token)
 
     def _send_to_scicat(self, cmd: str, endpoint: str, data: BaseModel = None):
         """sends a command to the SciCat API server using url and token, returns the response JSON

--- a/tests/test_pyscicat/test_client.py
+++ b/tests/test_pyscicat/test_client.py
@@ -9,6 +9,7 @@ from pyscicat.client import (
     encode_thumbnail,
     get_file_mod_time,
     get_file_size,
+    ScicatClient,
     ScicatCommError,
 )
 
@@ -217,5 +218,14 @@ def test_initializers():
     with requests_mock.Mocker() as mock_request:
         add_mock_requests(mock_request)
 
-        client = from_token(local_url, "let me in!")
-        assert client._token == "let me in!"
+        client = from_token(local_url, "a_token")
+        assert client._token == "a_token"
+        assert client._headers['Authorization'] == "Bearer a_token"
+
+        client = from_credentials(local_url, "Zaphod", "heartofgold")
+        assert client._token == "a_token"
+        assert client._headers['Authorization'] == "Bearer a_token"
+
+        client = ScicatClient(local_url, "a_token")
+        assert client._token == "a_token"
+        assert client._headers['Authorization'] == "Bearer a_token"


### PR DESCRIPTION
This fixes a bug where using from_credentials and from_token results in downstream auth errors because the `Authorziation: Bearer token` is not set.