### PR TITLE
Fix login

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -1,6 +1,7 @@
 name: Integration tests V4
 
 on:
+  push:
   pull_request:
     branches:
       - main

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,9 +3,8 @@ name: Unit Tests
 on:
   push:
   pull_request:
-  schedule:
-      - cron: '00 4 * * *'  # daily at 4AM
-
+    branches:
+      - main
 jobs:
 
   build:

--- a/pyscicat/client.py
+++ b/pyscicat/client.py
@@ -20,7 +20,7 @@ from pyscicat.model import (
     Sample,
 )
 
-logger = logging.getLogger("splash_ingest")
+logger = logging.getLogger("pyscicat")
 can_debug = logger.isEnabledFor(logging.DEBUG)
 
 

--- a/pyscicat/client.py
+++ b/pyscicat/client.py
@@ -814,6 +814,9 @@ def from_token(base_url: str, token: str):
 
 
 def from_credentials(base_url: str, username: str, password: str):
+    if not base_url.endswith('/'):
+        base_url += '/'
+        logger.warning(f"Base URL should end with a slash. Appending one to {base_url}")
     token = get_token(base_url, username, password)
     return from_token(base_url, token)
 

--- a/pyscicat/model.py
+++ b/pyscicat/model.py
@@ -73,10 +73,12 @@ class Sample(Ownable):
     description: Optional[str] = None
     sampleCharacteristics: Optional[dict] = None
     isPublished: bool = False
-    datasetsId: Optional[str]
-    datasetId: Optional[str]
-    rawDatasetId: Optional[str]
-    derivedDatasetId: Optional[str]
+    # Following were added, possibly by mistake. They do
+    # not match the current model in the SciCat backend.
+    datasetsId: Optional[str] = None
+    datasetId: Optional[str] = None
+    rawDatasetId: Optional[str] = None
+    derivedDatasetId: Optional[str] = None
 
 
 class Job(MongoQueryable):

--- a/pyscicat/model.py
+++ b/pyscicat/model.py
@@ -73,8 +73,6 @@ class Sample(Ownable):
     description: Optional[str] = None
     sampleCharacteristics: Optional[dict] = None
     isPublished: bool = False
-    # Following were added, possibly by mistake. They do
-    # not match the current model in the SciCat backend.
     datasetsId: Optional[str] = None
     datasetId: Optional[str] = None
     rawDatasetId: Optional[str] = None

--- a/tests/test_pyscicat/test_client.py
+++ b/tests/test_pyscicat/test_client.py
@@ -29,7 +29,7 @@ local_url = "http://localhost:3000/api/v3/"
 
 def add_mock_requests(mock_request):
     mock_request.post(
-        local_url + "Users/login",
+        local_url + "auth/login",
         json={"id": "a_token"},
     )
 
@@ -224,3 +224,11 @@ def test_initializers():
         client = ScicatClient(local_url, "a_token")
         assert client._token == "a_token"
         assert client._headers["Authorization"] == "Bearer a_token"
+
+
+def test_append_slash_base_url():
+    with requests_mock.Mocker() as mock_request:
+        add_mock_requests(mock_request)
+        slashless_url = local_url[:-1]
+        client = from_token(slashless_url, "a_token")
+        assert client._base_url == local_url

--- a/tests/test_pyscicat/test_client.py
+++ b/tests/test_pyscicat/test_client.py
@@ -232,3 +232,5 @@ def test_append_slash_base_url():
         slashless_url = local_url[:-1]
         client = from_token(slashless_url, "a_token")
         assert client._base_url == local_url
+        client = from_credentials(slashless_url, "Zaphod", "heartofgold")
+        assert client._base_url == local_url


### PR DESCRIPTION
Fixed #61 

This PR does several things:
* Changes the url that pyscicat logs in with to match the newer version of scicat_backend_next
* Removes the no-longer supported `msad` login endpoint login attempt
* Makes optional some fields in Sample model which are not supported currently. I would delete them but I think we're going to be scrapping these models soon anyway.
* If the provided `base_url` does not have a slash, adds one.
